### PR TITLE
feat: implement my mentor's feedback and zXplore compatibility

### DIFF
--- a/docs/DATASET_MANAGEMENT.md
+++ b/docs/DATASET_MANAGEMENT.md
@@ -85,8 +85,8 @@ dm, err := datasets.NewDatasetManagerFromProfile(zosmfProfile)
 // Direct connection
 dm, err := datasets.CreateDatasetManagerDirect("mainframe.example.com", 443, "user", "pass")
 
-// With additional options
-dm, err := datasets.CreateDatasetManagerDirectWithOptions("mainframe.example.com", 443, "user", "pass", false, "/api/v1")
+// With additional options (BasePath defaults to /zosmf if omitted)
+dm, err := datasets.CreateDatasetManagerDirectWithOptions("mainframe.example.com", 443, "user", "pass", false, "")
 ```
 
 ## API Reference

--- a/docs/JOB_MANAGEMENT.md
+++ b/docs/JOB_MANAGEMENT.md
@@ -14,9 +14,9 @@ The job management system consists of the following key components:
 
 ## Features
 
-- ✅ Submit jobs using JCL statements
-- ✅ Submit jobs from datasets
-- ✅ Submit jobs from local files
+- ✅ Submit jobs using JCL statements (via PUT)
+- ✅ Submit jobs from datasets (via PUT)
+- ✅ Submit jobs from local files (via PUT)
 - ✅ List jobs with filtering options
 - ✅ Get detailed job information
 - ✅ Monitor job status
@@ -83,8 +83,8 @@ jm, err := jobs.NewJobManagerFromProfile(zosmfProfile)
 // Direct connection
 jm, err := jobs.CreateJobManagerDirect("mainframe.example.com", 443, "user", "pass")
 
-// With additional options
-jm, err := jobs.CreateJobManagerDirectWithOptions("mainframe.example.com", 443, "user", "pass", false, "/api/v1")
+// With additional options (BasePath defaults to /zosmf if omitted)
+jm, err := jobs.CreateJobManagerDirectWithOptions("mainframe.example.com", 443, "user", "pass", false, "")
 ```
 
 ## API Reference
@@ -168,11 +168,13 @@ type JobFilter struct {
 - `CreateJobManagerDirect(host string, port int, user, password string) (*ZOSMFJobManager, error)`
 - `CreateJobManagerDirectWithOptions(host string, port int, user, password string, rejectUnauthorized bool, basePath string) (*ZOSMFJobManager, error)`
 
-#### Job Operations
+#### Job Operations (z/OSMF /restjobs)
 - `ListJobs(filter *JobFilter) (*JobList, error)`
 - `GetJob(jobID string) (*Job, error)`
 - `GetJobInfo(jobID string) (*JobInfo, error)`
 - `GetJobStatus(jobID string) (string, error)`
+- `GetJobByNameID(jobName, jobID string) (*Job, error)`
+- `GetJobByCorrelator(correlator string) (*Job, error)`
 - `SubmitJob(request *SubmitJobRequest) (*SubmitJobResponse, error)`
 - `CancelJob(jobID string) error`
 - `DeleteJob(jobID string) error`
@@ -244,10 +246,13 @@ jobList, err := jm.GetJobsByStatus("OUTPUT", 20)
 
 ```go
 // Get job status
-status, err := jm.GetJobStatus("JOB001")
+status, err := jm.GetJobStatus("<correlator>")
 
-// Get detailed job information
-job, err := jm.GetJob("JOB001")
+// Get detailed job information by correlator
+job, err := jm.GetJob("<correlator>")
+
+// Or get by job name and id
+job, err := jm.GetJobByNameID("JOBNAME", "JOB001")
 
 // Wait for job completion
 status, err := jm.WaitForJobCompletion("JOB001", 5*time.Minute, 10*time.Second)

--- a/pkg/datasets/datasets_test.go
+++ b/pkg/datasets/datasets_test.go
@@ -97,7 +97,7 @@ func TestListDatasets(t *testing.T) {
 	// Create test server
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, "GET", r.Method)
-		assert.Equal(t, "/api/v1/datasets", r.URL.Path)
+		assert.Equal(t, "/api/v1/restfiles/ds", r.URL.Path)
 		
 		// Return mock response
 		response := DatasetList{
@@ -135,7 +135,7 @@ func TestGetDataset(t *testing.T) {
 	// Create test server
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, "GET", r.Method)
-		assert.Equal(t, "/api/v1/datasets/TEST.DATA", r.URL.Path)
+		assert.Equal(t, "/api/v1/restfiles/ds/TEST.DATA", r.URL.Path)
 		
 		// Return mock response
 		response := Dataset{
@@ -167,7 +167,7 @@ func TestCreateDataset(t *testing.T) {
 	// Create test server
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, "POST", r.Method)
-		assert.Equal(t, "/api/v1/datasets", r.URL.Path)
+		assert.Equal(t, "/api/v1/restfiles/ds", r.URL.Path)
 		
 		// Parse request body
 		var requestBody map[string]interface{}
@@ -209,7 +209,7 @@ func TestDeleteDataset(t *testing.T) {
 	// Create test server
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, "DELETE", r.Method)
-		assert.Equal(t, "/api/v1/datasets/TEST.DATA", r.URL.Path)
+		assert.Equal(t, "/api/v1/restfiles/ds/TEST.DATA", r.URL.Path)
 		
 		w.WriteHeader(http.StatusNoContent)
 	}))
@@ -230,7 +230,7 @@ func TestUploadContent(t *testing.T) {
 	// Create test server
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, "POST", r.Method)
-		assert.Equal(t, "/api/v1/datasets/TEST.DATA/content", r.URL.Path)
+		assert.Equal(t, "/api/v1/restfiles/ds/TEST.DATA/content", r.URL.Path)
 		
 		// Parse request body
 		var requestBody map[string]interface{}
@@ -267,7 +267,7 @@ func TestDownloadContent(t *testing.T) {
 	// Create test server
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, "GET", r.Method)
-		assert.Equal(t, "/api/v1/datasets/TEST.DATA/content", r.URL.Path)
+		assert.Equal(t, "/api/v1/restfiles/ds/TEST.DATA/content", r.URL.Path)
 		
 		w.Header().Set("Content-Type", "text/plain")
 		w.Write([]byte("Hello, World!"))
@@ -295,7 +295,7 @@ func TestListMembers(t *testing.T) {
 	// Create test server
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, "GET", r.Method)
-		assert.Equal(t, "/api/v1/datasets/TEST.PDS/members", r.URL.Path)
+		assert.Equal(t, "/api/v1/restfiles/ds/TEST.PDS/members", r.URL.Path)
 		
 		// Return mock response
 		response := MemberList{
@@ -331,7 +331,7 @@ func TestGetMember(t *testing.T) {
 	// Create test server
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, "GET", r.Method)
-		assert.Equal(t, "/api/v1/datasets/TEST.PDS/members/MEMBER1", r.URL.Path)
+		assert.Equal(t, "/api/v1/restfiles/ds/TEST.PDS/members/MEMBER1", r.URL.Path)
 		
 		// Return mock response
 		response := DatasetMember{
@@ -361,7 +361,7 @@ func TestDeleteMember(t *testing.T) {
 	// Create test server
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, "DELETE", r.Method)
-		assert.Equal(t, "/api/v1/datasets/TEST.PDS/members/MEMBER1", r.URL.Path)
+		assert.Equal(t, "/api/v1/restfiles/ds/TEST.PDS/members/MEMBER1", r.URL.Path)
 		
 		w.WriteHeader(http.StatusNoContent)
 	}))
@@ -382,7 +382,7 @@ func TestExists(t *testing.T) {
 	// Create test server
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, "GET", r.Method)
-		assert.Equal(t, "/api/v1/datasets/TEST.DATA", r.URL.Path)
+		assert.Equal(t, "/api/v1/restfiles/ds/TEST.DATA", r.URL.Path)
 		
 		// Return mock response
 		response := Dataset{
@@ -411,7 +411,7 @@ func TestCopyDataset(t *testing.T) {
 	// Create test server
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, "POST", r.Method)
-		assert.Equal(t, "/api/v1/datasets/SOURCE.DATA/copy", r.URL.Path)
+		assert.Equal(t, "/api/v1/restfiles/ds/SOURCE.DATA/copy", r.URL.Path)
 		
 		// Parse request body
 		var requestBody map[string]interface{}
@@ -439,7 +439,7 @@ func TestRenameDataset(t *testing.T) {
 	// Create test server
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, "PUT", r.Method)
-		assert.Equal(t, "/api/v1/datasets/OLD.DATA/rename", r.URL.Path)
+		assert.Equal(t, "/api/v1/restfiles/ds/OLD.DATA/rename", r.URL.Path)
 		
 		// Parse request body
 		var requestBody map[string]interface{}
@@ -492,7 +492,7 @@ func TestCreateSequentialDataset(t *testing.T) {
 	// Create test server
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, "POST", r.Method)
-		assert.Equal(t, "/api/v1/datasets", r.URL.Path)
+		assert.Equal(t, "/api/v1/restfiles/ds", r.URL.Path)
 		
 		// Parse request body
 		var requestBody map[string]interface{}
@@ -527,7 +527,7 @@ func TestCreatePartitionedDataset(t *testing.T) {
 	// Create test server
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, "POST", r.Method)
-		assert.Equal(t, "/api/v1/datasets", r.URL.Path)
+		assert.Equal(t, "/api/v1/restfiles/ds", r.URL.Path)
 		
 		// Parse request body
 		var requestBody map[string]interface{}
@@ -563,7 +563,7 @@ func TestUploadText(t *testing.T) {
 	// Create test server
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, "POST", r.Method)
-		assert.Equal(t, "/api/v1/datasets/TEST.DATA/content", r.URL.Path)
+		assert.Equal(t, "/api/v1/restfiles/ds/TEST.DATA/content", r.URL.Path)
 		
 		// Parse request body
 		var requestBody map[string]interface{}
@@ -593,7 +593,7 @@ func TestUploadTextToMember(t *testing.T) {
 	// Create test server
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, "POST", r.Method)
-		assert.Equal(t, "/api/v1/datasets/TEST.PDS/content/MEMBER1", r.URL.Path)
+		assert.Equal(t, "/api/v1/restfiles/ds/TEST.PDS/content/MEMBER1", r.URL.Path)
 		
 		// Parse request body
 		var requestBody map[string]interface{}
@@ -623,7 +623,7 @@ func TestDownloadText(t *testing.T) {
 	// Create test server
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, "GET", r.Method)
-		assert.Equal(t, "/api/v1/datasets/TEST.DATA/content", r.URL.Path)
+		assert.Equal(t, "/api/v1/restfiles/ds/TEST.DATA/content", r.URL.Path)
 		assert.Equal(t, "UTF-8", r.URL.Query().Get("encoding"))
 		
 		w.Header().Set("Content-Type", "text/plain")
@@ -647,7 +647,7 @@ func TestDownloadTextFromMember(t *testing.T) {
 	// Create test server
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, "GET", r.Method)
-		assert.Equal(t, "/api/v1/datasets/TEST.PDS/content/MEMBER1", r.URL.Path)
+		assert.Equal(t, "/api/v1/restfiles/ds/TEST.PDS/content/MEMBER1", r.URL.Path)
 		assert.Equal(t, "UTF-8", r.URL.Query().Get("encoding"))
 		
 		w.Header().Set("Content-Type", "text/plain")

--- a/pkg/datasets/manager.go
+++ b/pkg/datasets/manager.go
@@ -12,9 +12,9 @@ import (
 	"github.com/ojuschugh1/zowe-client-go-sdk/pkg/profile"
 )
 
-// API endpoint constants
+// API endpoint constants aligned to z/OSMF dataset APIs
 const (
-	DatasetsEndpoint = "/datasets"
+	DatasetsEndpoint = "/restfiles/ds"
 	MembersEndpoint  = "/members"
 	ContentEndpoint  = "/content"
 )
@@ -44,6 +44,7 @@ func (dm *ZOSMFDatasetManager) ListDatasets(filter *DatasetFilter) (*DatasetList
 	if filter != nil {
 		if filter.Name != "" {
 			params.Set("dsname", filter.Name)
+			params.Set("dslevel", filter.Name)
 		}
 		if filter.Type != "" {
 			params.Set("dsorg", filter.Type)

--- a/pkg/jobs/jobs_test.go
+++ b/pkg/jobs/jobs_test.go
@@ -98,7 +98,7 @@ func TestListJobs(t *testing.T) {
 	// Create test server
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, "GET", r.Method)
-		assert.Equal(t, "/api/v1/jobs", r.URL.Path)
+		assert.Equal(t, "/api/v1/restjobs/jobs", r.URL.Path)
 		
 		// Check query parameters
 		assert.Equal(t, "testuser", r.URL.Query().Get("owner"))
@@ -155,7 +155,7 @@ func TestGetJob(t *testing.T) {
 	// Create test server
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, "GET", r.Method)
-		assert.Equal(t, "/api/v1/jobs/JOB001", r.URL.Path)
+		assert.Equal(t, "/api/v1/restjobs/jobs/JOB001", r.URL.Path)
 		
 		// Return mock response
 		job := Job{
@@ -193,7 +193,7 @@ func TestGetJobStatus(t *testing.T) {
 	// Create test server
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, "GET", r.Method)
-		assert.Equal(t, "/api/v1/jobs/JOB001", r.URL.Path)
+		assert.Equal(t, "/api/v1/restjobs/jobs/JOB001", r.URL.Path)
 		
 		// Return mock response
 		job := Job{
@@ -225,8 +225,8 @@ func TestGetJobStatus(t *testing.T) {
 func TestSubmitJob(t *testing.T) {
 	// Create test server
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		assert.Equal(t, "POST", r.Method)
-		assert.Equal(t, "/api/v1/jobs", r.URL.Path)
+		assert.Equal(t, "PUT", r.Method)
+		assert.Equal(t, "/api/v1/restjobs/jobs", r.URL.Path)
 		
 		// Parse request body
 		var requestBody map[string]string
@@ -271,8 +271,8 @@ func TestSubmitJob(t *testing.T) {
 func TestSubmitJobStatement(t *testing.T) {
 	// Create test server
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		assert.Equal(t, "POST", r.Method)
-		assert.Equal(t, "/api/v1/jobs", r.URL.Path)
+		assert.Equal(t, "PUT", r.Method)
+		assert.Equal(t, "/api/v1/restjobs/jobs", r.URL.Path)
 		
 		// Return mock response
 		response := SubmitJobResponse{
@@ -305,8 +305,8 @@ func TestSubmitJobStatement(t *testing.T) {
 func TestSubmitJobFromDataset(t *testing.T) {
 	// Create test server
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		assert.Equal(t, "POST", r.Method)
-		assert.Equal(t, "/api/v1/jobs", r.URL.Path)
+		assert.Equal(t, "PUT", r.Method)
+		assert.Equal(t, "/api/v1/restjobs/jobs", r.URL.Path)
 		
 		// Return mock response
 		response := SubmitJobResponse{
@@ -340,7 +340,7 @@ func TestCancelJob(t *testing.T) {
 	// Create test server
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, "PUT", r.Method)
-		assert.Equal(t, "/api/v1/jobs/JOB001/cancel", r.URL.Path)
+		assert.Equal(t, "/api/v1/restjobs/jobs/JOB001/cancel", r.URL.Path)
 		
 		w.WriteHeader(http.StatusNoContent)
 	}))
@@ -363,7 +363,7 @@ func TestDeleteJob(t *testing.T) {
 	// Create test server
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, "DELETE", r.Method)
-		assert.Equal(t, "/api/v1/jobs/JOB001", r.URL.Path)
+		assert.Equal(t, "/api/v1/restjobs/jobs/JOB001", r.URL.Path)
 		
 		w.WriteHeader(http.StatusNoContent)
 	}))
@@ -386,7 +386,7 @@ func TestGetSpoolFiles(t *testing.T) {
 	// Create test server
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, "GET", r.Method)
-		assert.Equal(t, "/api/v1/jobs/JOB001/files", r.URL.Path)
+		assert.Equal(t, "/api/v1/restjobs/jobs/JOB001/files", r.URL.Path)
 		
 		// Return mock response
 		spoolFiles := []SpoolFile{
@@ -431,7 +431,7 @@ func TestGetSpoolFileContent(t *testing.T) {
 	// Create test server
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, "GET", r.Method)
-		assert.Equal(t, "/api/v1/jobs/JOB001/files/1/records", r.URL.Path)
+		assert.Equal(t, "/api/v1/restjobs/jobs/JOB001/files/1/records", r.URL.Path)
 		
 		// Return mock content
 		w.Header().Set("Content-Type", "text/plain")
@@ -457,7 +457,7 @@ func TestPurgeJob(t *testing.T) {
 	// Create test server
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, "PUT", r.Method)
-		assert.Equal(t, "/api/v1/jobs/JOB001/purge", r.URL.Path)
+		assert.Equal(t, "/api/v1/restjobs/jobs/JOB001/purge", r.URL.Path)
 		
 		w.WriteHeader(http.StatusNoContent)
 	}))
@@ -560,7 +560,7 @@ func TestGetJobsByOwner(t *testing.T) {
 	// Create test server
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, "GET", r.Method)
-		assert.Equal(t, "/api/v1/jobs", r.URL.Path)
+		assert.Equal(t, "/api/v1/restjobs/jobs", r.URL.Path)
 		assert.Equal(t, "testuser", r.URL.Query().Get("owner"))
 		assert.Equal(t, "10", r.URL.Query().Get("max-jobs"))
 		
@@ -600,7 +600,7 @@ func TestGetJobsByPrefix(t *testing.T) {
 	// Create test server
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, "GET", r.Method)
-		assert.Equal(t, "/api/v1/jobs", r.URL.Path)
+		assert.Equal(t, "/api/v1/restjobs/jobs", r.URL.Path)
 		assert.Equal(t, "TEST", r.URL.Query().Get("prefix"))
 		assert.Equal(t, "5", r.URL.Query().Get("max-jobs"))
 		
@@ -640,7 +640,7 @@ func TestGetJobsByStatus(t *testing.T) {
 	// Create test server
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, "GET", r.Method)
-		assert.Equal(t, "/api/v1/jobs", r.URL.Path)
+		assert.Equal(t, "/api/v1/restjobs/jobs", r.URL.Path)
 		assert.Equal(t, "OUTPUT", r.URL.Query().Get("status"))
 		assert.Equal(t, "20", r.URL.Query().Get("max-jobs"))
 		
@@ -898,8 +898,8 @@ func TestWaitForJobCompletionError(t *testing.T) {
 func TestSubmitJobWithAllSources(t *testing.T) {
 	// Create test server
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		assert.Equal(t, "POST", r.Method)
-		assert.Equal(t, "/api/v1/jobs", r.URL.Path)
+		assert.Equal(t, "PUT", r.Method)
+		assert.Equal(t, "/api/v1/restjobs/jobs", r.URL.Path)
 		
 		// Parse request body
 		var requestBody map[string]interface{}
@@ -948,7 +948,7 @@ func TestListJobsWithAllFilters(t *testing.T) {
 	// Create test server
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, "GET", r.Method)
-		assert.Equal(t, "/api/v1/jobs", r.URL.Path)
+		assert.Equal(t, "/api/v1/restjobs/jobs", r.URL.Path)
 		
 		// Check all query parameters
 		assert.Equal(t, "testuser", r.URL.Query().Get("owner"))
@@ -1002,7 +1002,7 @@ func TestGetJobInfo(t *testing.T) {
 	// Create test server
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, "GET", r.Method)
-		assert.Equal(t, "/api/v1/jobs/JOB001/files", r.URL.Path)
+		assert.Equal(t, "/api/v1/restjobs/jobs/JOB001/files", r.URL.Path)
 		
 		response := JobInfo{
 			JobID:   "JOB001",

--- a/pkg/jobs/types.go
+++ b/pkg/jobs/types.go
@@ -100,6 +100,8 @@ type JobManager interface {
 	GetJob(jobID string) (*Job, error)
 	GetJobInfo(jobID string) (*JobInfo, error)
 	GetJobStatus(jobID string) (string, error)
+	GetJobByNameID(jobName, jobID string) (*Job, error)
+	GetJobByCorrelator(correlator string) (*Job, error)
 	SubmitJob(request *SubmitJobRequest) (*SubmitJobResponse, error)
 	CancelJob(jobID string) error
 	DeleteJob(jobID string) error

--- a/pkg/profile/profile_test.go
+++ b/pkg/profile/profile_test.go
@@ -246,7 +246,7 @@ func TestCreateSessionDirect(t *testing.T) {
 	assert.Equal(t, 443, session.Port)
 	assert.Equal(t, "user", session.User)
 	assert.Equal(t, "pass", session.Password)
-	assert.Equal(t, "https://localhost", session.BaseURL)
+	assert.Equal(t, "https://localhost/zosmf", session.BaseURL)
 }
 
 func TestCreateSessionDirectWithOptions(t *testing.T) {
@@ -428,7 +428,7 @@ func TestSessionWithDifferentProtocols(t *testing.T) {
 				Host: "localhost",
 				Port: 443,
 			},
-			expected: "https://localhost",
+			expected: "https://localhost/zosmf",
 		},
 		{
 			name: "http port 80",
@@ -436,7 +436,7 @@ func TestSessionWithDifferentProtocols(t *testing.T) {
 				Host: "localhost",
 				Port: 80,
 			},
-			expected: "http://localhost",
+			expected: "http://localhost/zosmf",
 		},
 		{
 			name: "http port 8080",
@@ -444,7 +444,7 @@ func TestSessionWithDifferentProtocols(t *testing.T) {
 				Host: "localhost",
 				Port: 8080,
 			},
-			expected: "http://localhost:8080",
+			expected: "http://localhost:8080/zosmf",
 		},
 		{
 			name: "custom port",
@@ -452,7 +452,7 @@ func TestSessionWithDifferentProtocols(t *testing.T) {
 				Host: "localhost",
 				Port: 8443,
 			},
-			expected: "https://localhost:8443",
+			expected: "https://localhost:8443/zosmf",
 		},
 		{
 			name: "explicit protocol",
@@ -461,7 +461,7 @@ func TestSessionWithDifferentProtocols(t *testing.T) {
 				Port:     443,
 				Protocol: "http",
 			},
-			expected: "http://localhost",
+			expected: "http://localhost/zosmf",
 		},
 	}
 

--- a/pkg/profile/session.go
+++ b/pkg/profile/session.go
@@ -2,6 +2,7 @@ package profile
 
 import (
 	"crypto/tls"
+	"encoding/base64"
 	"fmt"
 	"net/http"
 	"time"
@@ -38,15 +39,26 @@ func (p *ZOSMFProfile) NewSession() (*Session, error) {
 	if p.Port != 0 && p.Port != 80 && p.Port != 443 {
 		baseURL += ":" + fmt.Sprintf("%d", p.Port)
 	}
-	
-	if p.BasePath != "" {
-		baseURL += p.BasePath
+
+	// Default BasePath to /zosmf if not specified
+	basePath := p.BasePath
+	if basePath == "" {
+		basePath = "/zosmf"
 	}
+	// Ensure leading slash
+	if basePath[0] != '/' {
+		basePath = "/" + basePath
+	}
+	baseURL += basePath
 	
 	// Set default headers
 	headers := map[string]string{
 		"Content-Type": "application/json",
 		"Accept":       "application/json",
+	}
+	if p.User != "" && p.Password != "" {
+		b := base64.StdEncoding.EncodeToString([]byte(p.User + ":" + p.Password))
+		headers["Authorization"] = "Basic " + b
 	}
 	
 	return &Session{


### PR DESCRIPTION
- Change job submission HTTP method from POST to PUT per z/OSMF docs
- Default BasePath to /zosmf in session.go when not specified
- Refactor job endpoint constants to use /restjobs templates
- Add GetJobByNameID and GetJobByCorrelator methods
- Update job methods to use correlator parameter consistently
- Add Basic Authentication header support in session
- Implement backward compatibility for job list responses (array/object)
- Add dslevel parameter for dataset listing compatibility
- Update all unit tests to reflect new API changes
- Refactor test_zxplore_github.go to use SDK managers exclusively
- Update documentation to reflect new API methods
- Fix GitHub Actions workflow for integration testing